### PR TITLE
Split up extra dependencies as multiple outputs, add maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @igortg @lvoliveira @xmnlab
+* @bollwyvl @igortg @lvoliveira @xmnlab

--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@ Package license: BSD-3-Clause
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/sqlalchemy-utils-feedstock/blob/main/LICENSE.txt)
 
-Summary: Various utility functions for SQLAlchemy
-
-Development: https://github.com/kvesteri/sqlalchemy-utils
-
-Documentation: https://sqlalchemy-utils.readthedocs.io
+Summary: Various utility functions for SQLAlchemy (with no extras)
 
 Current build status
 ====================
@@ -32,6 +28,17 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--arrow-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-arrow) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-arrow.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-arrow) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-arrow.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-arrow) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-arrow.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-arrow) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--babel-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-babel) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-babel.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-babel) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-babel.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-babel) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-babel.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-babel) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--base-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-base.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-base.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-base.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-base) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--color-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-color) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-color.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-color) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-color.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-color) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-color.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-color) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--encrypted-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-encrypted) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-encrypted.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-encrypted) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-encrypted.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-encrypted) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-encrypted.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-encrypted) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--intervals-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-intervals) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-intervals.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-intervals) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-intervals.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-intervals) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-intervals.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-intervals) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--password-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-password) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-password.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-password) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-password.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-password) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-password.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-password) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--pendulum-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-pendulum) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-pendulum.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-pendulum) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-pendulum.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-pendulum) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-pendulum.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-pendulum) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--phone-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-phone) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-phone.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-phone) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-phone.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-phone) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-phone.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-phone) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--timezone-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-timezone) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-timezone.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-timezone) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-timezone.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-timezone) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-timezone.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-timezone) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sqlalchemy--utils--url-green.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-url) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlalchemy-utils-url.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-url) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlalchemy-utils-url.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-url) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlalchemy-utils-url.svg)](https://anaconda.org/conda-forge/sqlalchemy-utils-url) |
 
 Installing sqlalchemy-utils
 ===========================
@@ -43,16 +50,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `sqlalchemy-utils` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `sqlalchemy-utils, sqlalchemy-utils-arrow, sqlalchemy-utils-babel, sqlalchemy-utils-base, sqlalchemy-utils-color, sqlalchemy-utils-encrypted, sqlalchemy-utils-intervals, sqlalchemy-utils-password, sqlalchemy-utils-pendulum, sqlalchemy-utils-phone, sqlalchemy-utils-timezone, sqlalchemy-utils-url` can be installed with `conda`:
 
 ```
-conda install sqlalchemy-utils
+conda install sqlalchemy-utils sqlalchemy-utils-arrow sqlalchemy-utils-babel sqlalchemy-utils-base sqlalchemy-utils-color sqlalchemy-utils-encrypted sqlalchemy-utils-intervals sqlalchemy-utils-password sqlalchemy-utils-pendulum sqlalchemy-utils-phone sqlalchemy-utils-timezone sqlalchemy-utils-url
 ```
 
 or with `mamba`:
 
 ```
-mamba install sqlalchemy-utils
+mamba install sqlalchemy-utils sqlalchemy-utils-arrow sqlalchemy-utils-babel sqlalchemy-utils-base sqlalchemy-utils-color sqlalchemy-utils-encrypted sqlalchemy-utils-intervals sqlalchemy-utils-password sqlalchemy-utils-pendulum sqlalchemy-utils-phone sqlalchemy-utils-timezone sqlalchemy-utils-url
 ```
 
 It is possible to list all of the versions of `sqlalchemy-utils` available on your platform with `conda`:
@@ -147,6 +154,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@bollwyvl](https://github.com/bollwyvl/)
 * [@igortg](https://github.com/igortg/)
 * [@lvoliveira](https://github.com/lvoliveira/)
 * [@xmnlab](https://github.com/xmnlab/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
 {% set version = "0.38.3" %}
+{% set min_sqlalchemy = "1.3" %}
 
 package:
-  name: sqlalchemy-utils
+  name: sqlalchemy-utils-split
   version: {{ version }}
 
 source:
@@ -9,42 +10,339 @@ source:
   sha256: 9f9afba607a40455cf703adfa9846584bf26168a0c5a60a70063b70d65051f4d
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.4
+    - python >=3.6
     - pip
   run:
-    - python >=3.4
-    - six
-    - sqlalchemy >=1.0
-    # extras
-    - anyjson >=0.3.3
-    - babel >=1.3
-    - arrow >=0.3.4
-    - pendulum >=2.0.5
-    - intervals >=0.7.1
-    - phonenumbers >=5.9.2
-    - passlib >=1.6,<2.0
-    - colour >=0.0.4
-    - python-dateutil
-    - furl >=0.4.1
-    - cryptography >=0.6
+    - python >=3.6
 
-test:
-  imports:
-    - sqlalchemy_utils
-    - sqlalchemy_utils.functions
-    - sqlalchemy_utils.primitives
-    - sqlalchemy_utils.relationships
-    - sqlalchemy_utils.types
-  requires:
-    - pip
-  commands:
-    - pip check
+outputs:
+  - name: sqlalchemy-utils-base
+    build:
+      number: 1
+      noarch: python
+      script: {{ PYTHON }} -m pip install . -vv --no-deps
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - python >=3.6
+        - sqlalchemy >={{ min_sqlalchemy }}
+        # technically, python_version<'3.8': not worth the loss of `noarch: python`
+        - importlib-metadata
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with no extras)
+
+  - name: sqlalchemy-utils-arrow
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - arrow >=0.3.4
+        - python >=3.6
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with `[arrow]` extra)
+
+  - name: sqlalchemy-utils-babel
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - babel >=1.3
+        - python >=3.6
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with `[babel]` extra)
+
+  - name: sqlalchemy-utils-color
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - colour >=0.0.4
+        - python >=3.6
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with `[color]` extra)
+
+  - name: sqlalchemy-utils-encrypted
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - cryptography >=0.6
+        - python >=3.6
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with `[encrypted]` extra)
+
+  - name: sqlalchemy-utils-intervals
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - python >=3.6
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - intervals >=0.7.1
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with `[intervals]` extra)
+
+  - name: sqlalchemy-utils-password
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - python >=3.6
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - passlib >=1.6,<2.0
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with `[password]` extra)
+
+  - name: sqlalchemy-utils-pendulum
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - python >=3.6
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - pendulum >=2.0.5
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with `[pendulum]` extra)
+
+  - name: sqlalchemy-utils-phone
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - python >=3.6
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - phonenumbers >=5.9.2
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with `[phone]` extra)
+
+  - name: sqlalchemy-utils-timezone
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - python >=3.6
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - python-dateutil
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with `[timezone]` extra)
+
+  - name: sqlalchemy-utils-url
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - python >=3.6
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - furl >=0.4.1
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with `[url]` extra)
+
+  - name: sqlalchemy-utils
+    build:
+      number: 1
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.6
+      run:
+        - python >=3.6
+        - {{ pin_subpackage("sqlalchemy-utils-base", max_pin="x.x.x") }}
+        - {{ pin_subpackage("sqlalchemy-utils-arrow", max_pin="x.x.x") }}
+        - {{ pin_subpackage("sqlalchemy-utils-babel", max_pin="x.x.x") }}
+        - {{ pin_subpackage("sqlalchemy-utils-color", max_pin="x.x.x") }}
+        - {{ pin_subpackage("sqlalchemy-utils-encrypted", max_pin="x.x.x") }}
+        - {{ pin_subpackage("sqlalchemy-utils-intervals", max_pin="x.x.x") }}
+        - {{ pin_subpackage("sqlalchemy-utils-password", max_pin="x.x.x") }}
+        - {{ pin_subpackage("sqlalchemy-utils-pendulum", max_pin="x.x.x") }}
+        - {{ pin_subpackage("sqlalchemy-utils-phone", max_pin="x.x.x") }}
+        - {{ pin_subpackage("sqlalchemy-utils-timezone", max_pin="x.x.x") }}
+        - {{ pin_subpackage("sqlalchemy-utils-url", max_pin="x.x.x") }}
+    test:
+      imports:
+        - sqlalchemy_utils
+      requires:
+        - pip
+      commands:
+        - pip check
+    about:
+      home: https://github.com/kvesteri/sqlalchemy-utils
+      license_file: LICENSE
+      license: BSD-3-Clause
+      license_family: BSD
+      summary: Various utility functions for SQLAlchemy (with all extras)
 
 about:
   home: https://github.com/kvesteri/sqlalchemy-utils
@@ -56,7 +354,9 @@ about:
   doc_url: https://sqlalchemy-utils.readthedocs.io
 
 extra:
+  feedstock-name: sqlalchemy-utils
   recipe-maintainers:
     - lvoliveira
     - igortg
     - xmnlab
+    - bollwyvl


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- thanks for maintaining this!
- synchronize `sqlalchemy-utils` base dependencies with upstream, captured as `sqlalchemy-utils-base` which contains the actual code
- split up all the extras into individual packages that depend on `-base`
- `sqlalchemy-utils` now a metapackage that brings in all the others
- remove vendored license, as is now included in the sdist
- adds self as maintainer :wave: