### PR TITLE
Removing igortg from the maintainers list

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -369,6 +369,5 @@ extra:
   feedstock-name: sqlalchemy-utils
   recipe-maintainers:
     - lvoliveira
-    - igortg
     - xmnlab
     - bollwyvl


### PR DESCRIPTION
I'm trying to reduce the list of packages I'm a maintainer.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
